### PR TITLE
Enable escape and click-outside dismissal for palette modal

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -488,7 +488,7 @@ class App {
     const cancelEditPaletteButton = document.getElementById("cancelEditPaletteButton");
     if (cancelEditPaletteButton) {
       cancelEditPaletteButton.addEventListener("click", () => {
-        this.uiManager.hideEditPaletteModal();
+        this.uiManager.attemptHideEditPaletteModal();
       });
     } else {
         console.warn("[main.js] cancelEditPaletteButton element not found.");
@@ -497,7 +497,7 @@ class App {
     const closeEditModalButton = document.getElementById("closeEditModal");
     if (closeEditModalButton) {
         closeEditModalButton.addEventListener("click", () => {
-            this.uiManager.hideEditPaletteModal();
+            this.uiManager.attemptHideEditPaletteModal();
         });
     } else {
         console.warn("[main.js] closeEditModalButton element not found.");


### PR DESCRIPTION
## Summary
- let Escape or click outside close the palette editor modal
- warn about unsaved palette changes

## Testing
- `cargo check` *(fails: failed to download due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_68595226bcf8832e86e1f647dea4d605

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a confirmation prompt to prevent accidental closing of the palette editor modal when there are unsaved changes.
  - The palette editor now tracks unsaved changes and alerts users before discarding edits.

- **Improvements**
  - Enhanced modal behavior to detect clicks outside the modal and Escape key presses, prompting for confirmation if there are unsaved changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->